### PR TITLE
Switch to webhooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 history.txt
+repo-watcher

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,5 @@ WORKDIR /repo-watcher
 COPY . .
 RUN go build -o repo-watcher
 
+EXPOSE 3100
 CMD ["/repo-watcher/repo-watcher"]

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,3 @@
 .PHONY: start
 start:
-	@go run main.go service.go
+	@go run main.go service.go server.go

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A Ruby application that provides desktop notifications from a GHe repo
 
 #### App Config
 Fill out the following values appropriately
-- token
+- ~~token~~
     - GitHub Personal Access Token
 - org_name
     - The organization that owns the repository
@@ -28,9 +28,8 @@ Fill out the following values appropriately
 - slack_webhook
     - The webhook you set up for your Slack app
 
-#### Turn up the volume
-As of now, I'm relying on `say` for this to actually notify the user, so you'll
-need to be able to hear it.
+#### Write your deployment manifest
+- Configure and deploy your app anywhere that has access to your GitHub Enterprise repository.
 
 #### Set up the Slack App
 - Create a slack app and set up an incoming webhook so you can post messages to a slack channel
@@ -38,16 +37,5 @@ need to be able to hear it.
 #### Start the server
 In a terminal session, run `make start`
 
-## How to get a Personal Access Token?
-- Log in to your repository
-- Click your icon in the top right corner
-- Click "Developer Settings" on the bottom of the left panel
-- Click "Personal access tokens" on the bottom of the left panel
-- Click "Generate new token"
-    - Name it whatever you want
-    - Give the token the following scopes
-        - repo (top level)
-        - notifications
-        - user (top level)
-        - read:discussion
-- Copy the token value and paste it into the app config "token" value
+## How to configure your webhooks?
+- TODO

--- a/app.yaml
+++ b/app.yaml
@@ -23,6 +23,5 @@ development:
   refresh_seconds: 30
   repo_to_watch: ""
   log_level: "info"
-  run_type: "solo"
   run_type: "api"
   

--- a/app.yaml
+++ b/app.yaml
@@ -24,4 +24,5 @@ development:
   repo_to_watch: ""
   log_level: "info"
   run_type: "solo"
+  run_type: "api"
   

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3.4'
+
+services:
+  app:
+    container_name: repo-watcher
+    command: >
+      bash -c "make start"
+    build:
+      context: .
+    ports:
+    - 3100:3100

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/mike-webster/repo-watcher
 
 require (
-	github.com/gin-gonic/gin v1.6.2 // indirect
+	github.com/gin-gonic/gin v1.6.2
 	gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0
 	repos.wyzdev.com/wyzant-web/citizen v0.5.0
 )

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,9 @@
 module github.com/mike-webster/repo-watcher
 
 require (
+	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869
 	github.com/gin-gonic/gin v1.6.2
+	github.com/kr/pretty v0.2.0 // indirect
+	github.com/stretchr/testify v1.4.0
 	gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0
-	repos.wyzdev.com/wyzant-web/citizen v0.5.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
+github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -16,6 +18,11 @@ github.com/golang/protobuf v1.3.3 h1:gyjaxf+svBWX08ZjK86iN9geUJF0H6gp2IRKX6Nf6/I
 github.com/golang/protobuf v1.3.3/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
+github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
+github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/leodido/go-urn v1.2.0 h1:hpXL4XnriNwQ/ABnpepYM/1vCLWNDfUNts8dX3xTG6Y=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
@@ -43,5 +50,3 @@ gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0/go.mod h1:WDnlLJ4WF5VGsH/HVa
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-repos.wyzdev.com/wyzant-web/citizen v0.5.0 h1:75gI+GwB26RSo2U8wH5CI8cZhEaeQniifuzMsQgrwmo=
-repos.wyzdev.com/wyzant-web/citizen v0.5.0/go.mod h1:EGsgVedtX2J6nXU64Y+XB40icMl5N94YNxjJ7Y9mU2w=

--- a/main.go
+++ b/main.go
@@ -34,12 +34,7 @@ func main() {
 		}
 	} else if cfg.RunType == "api" {
 		Log("...Run type: api...", "info")
-		s := &server{}
-		http.Handle("/", s)
-		err := http.ListenAndServe(fmt.Sprintf(":%v", cfg.Port), nil)
-		if err != nil {
-			Log(err.Error(), "error")
-		}
+		startServer(cfg.Port)
 	}
 
 	Log("...stopping monitoring...", "info")

--- a/main.go
+++ b/main.go
@@ -34,7 +34,11 @@ func main() {
 		}
 	} else if cfg.RunType == "api" {
 		Log("...Run type: api...", "info")
-		startServer(cfg.Port)
+		router := SetupServer(fmt.Sprint(cfg.Port))
+		err := router.Run()
+		if err != nil {
+			panic(err)
+		}
 	}
 
 	Log("...stopping monitoring...", "info")

--- a/main.go
+++ b/main.go
@@ -32,6 +32,14 @@ func main() {
 			Log(fmt.Sprint("...sleep duration: ", sleep, " seconds..."), "info")
 			time.Sleep(sleep)
 		}
+	} else if cfg.RunType == "api" {
+		Log("...Run type: api...", "info")
+		s := &server{}
+		http.Handle("/", s)
+		err := http.ListenAndServe(fmt.Sprintf(":%v", cfg.Port), nil)
+		if err != nil {
+			Log(err.Error(), "error")
+		}
 	}
 
 	Log("...stopping monitoring...", "info")

--- a/server.go
+++ b/server.go
@@ -1,0 +1,11 @@
+package main
+
+import "net/http"
+
+type server struct{}
+
+func (s *server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte(`{"message":"hello world"}`))
+}

--- a/server.go
+++ b/server.go
@@ -1,11 +1,34 @@
 package main
 
-import "net/http"
+import (
+	"fmt"
 
-type server struct{}
+	"github.com/gin-gonic/gin"
+)
 
-func (s *server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-	w.Write([]byte(`{"message":"hello world"}`))
+const CODE_OK int = 200
+const CODE_INVALID int = 400
+const CODE_UNAUTH int = 401
+
+func startServer(port int) {
+	r := gin.Default()
+	r.GET("/", handlerHealtcheck)
+
+	r.Group("/v1")
+	{
+		r.POST("/github", handlerGitHub)
+	}
+	r.Run(fmt.Sprintf(":%v", port))
+}
+
+func handlerHealtcheck(ctx *gin.Context) {
+	ctx.JSON(CODE_OK, fmt.Sprintf("{\"%v\":\"%v\"}", "message", "ok"))
+}
+
+func handlerGitHub(ctx *gin.Context) {
+	eventName := ctx.Request.Header["X-GitHub-Event"]
+	secret := ctx.Request.Header["X-Hub-Signature"]
+	body := ctx.Request.PostForm
+	message := "Incoming GH WH request:\n\tevent: %v,\n\tsecret: %v, \n\tbody: %v"
+	Log(fmt.Sprintf(message, eventName, secret, body), "info")
 }

--- a/server.go
+++ b/server.go
@@ -1,34 +1,245 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/gin-gonic/gin"
+	env "github.com/mike-webster/repo-watcher/env"
+	webhookmodels "github.com/mike-webster/repo-watcher/webhookmodels"
 )
 
-const CODE_OK int = 200
-const CODE_INVALID int = 400
-const CODE_UNAUTH int = 401
+// CodeOK is for a 200 response
+const CodeOK int = 200
 
-func startServer(port int) {
-	r := gin.Default()
-	r.GET("/", handlerHealtcheck)
+// CodeNoContent is for a 204 response
+const CodeNoContent int = 204
 
-	r.Group("/v1")
+// CodeInvalid is for a 400 response
+const CodeInvalid int = 400
+
+// CodeUnauth is for a 401 response
+const CodeUnauth int = 401
+
+const errInvalidSecret = "Invalid request secret"
+const errMissingEvent = "Missing event value"
+const errInvalidBody = "Invalid POST body"
+const errInvalidHeader = "Invalid request headers"
+
+type ApiServer interface {
+	Start() error
+}
+
+type Server struct {
+	Engine *gin.Engine
+	Port   string
+}
+
+func (s *Server) Run() error {
+	return s.Engine.Run(fmt.Sprintf(":%v", s.Port))
+}
+
+func SetupServer(port string) *Server {
+	router := gin.Default()
+	router.GET("/", handlerHealtcheck)
+
+	v1 := router.Group("/v1")
 	{
-		r.POST("/github", handlerGitHub)
+		v1.POST("/github", handlerGitHub)
 	}
-	r.Run(fmt.Sprintf(":%v", port))
+
+	return &Server{
+		Port:   port,
+		Engine: router,
+	}
 }
 
 func handlerHealtcheck(ctx *gin.Context) {
-	ctx.JSON(CODE_OK, fmt.Sprintf("{\"%v\":\"%v\"}", "message", "ok"))
+	ctx.JSON(CodeOK, fmt.Sprintf("{\"%v\":\"%v\"}", "message", "ok"))
+}
+
+type ghRequestHeader struct {
+	Event  string `header:"X-GitHub-Event" binding:"required"`
+	Secret string `header:"X-Hub-Signature" binding:"required"`
+}
+
+func (ghrh *ghRequestHeader) ToString() string {
+	return fmt.Sprint("Event: ", ghrh.Event, " -- Secret: ", ghrh.Secret)
 }
 
 func handlerGitHub(ctx *gin.Context) {
-	eventName := ctx.Request.Header["X-GitHub-Event"]
-	secret := ctx.Request.Header["X-Hub-Signature"]
-	body := ctx.Request.PostForm
-	message := "Incoming GH WH request:\n\tevent: %v,\n\tsecret: %v, \n\tbody: %v"
-	Log(fmt.Sprintf(message, eventName, secret, body), "info")
+	hdr := &ghRequestHeader{}
+	err := ctx.BindHeader(hdr)
+	if err != nil {
+		Log(fmt.Sprint("invalid request header; error: ", err.Error()), "error")
+
+		errs := strings.Split(err.Error(), "\n")
+		msg := ""
+		for _, e := range errs {
+			v := strings.Replace(e, "Key: ", "", 1)
+			msg += fmt.Sprintf("\"%v\":\"%v\",", "reason", v)
+		}
+		msg = fmt.Sprintf("{%v}", strings.TrimRight(msg, ","))
+		ctx.JSON(CodeInvalid, msg)
+		return
+	}
+
+	summary, errCode, err := parseEventMessage(hdr.Event, ctx)
+	if err != nil {
+		Log(err.Error(), "error")
+		if errCode == CodeInvalid {
+			errs := strings.Split(err.Error(), "\n")
+			msg := ""
+			for _, e := range errs {
+				v := strings.Replace(e, "Key: ", "", 1)
+				msg += fmt.Sprintf("\"%v\":\"%v\",", "reason", v)
+			}
+			msg = fmt.Sprintf("{%v}", strings.TrimRight(msg, ","))
+			ctx.JSON(CodeInvalid, msg)
+			return
+		}
+	}
+
+	if len(summary) > 0 {
+		sendMessageToSlack(summary)
+	}
+	ctx.Status(CodeNoContent)
+}
+
+func parseEventMessage(event string, ctx *gin.Context) (string, int, error) {
+	message := ""
+	username := ""
+	var err error
+
+	if event == "create" {
+		event := &webhookmodels.CreateEventPayload{}
+		err = ctx.BindJSON(event)
+		if err == nil {
+			message = event.ToString()
+			username = event.Sender.Login
+		} else {
+			Log(err.Error(), "error")
+		}
+	} else if event == "gollum" {
+		event := &webhookmodels.GollumEventPayload{}
+		err = ctx.BindJSON(event)
+		if err == nil {
+			message = event.ToString()
+			username = event.Sender.Login
+		} else {
+			Log(err.Error(), "error")
+		}
+	} else if event == "issues" {
+		event := &webhookmodels.IssuesEventPayload{}
+		err = ctx.BindJSON(event)
+		if err == nil {
+			message = event.ToString()
+			username = event.Sender.Login
+		} else {
+			Log(err.Error(), "error")
+		}
+	} else if event == "issue_comment" {
+		event := &webhookmodels.IssueCommentEventPayload{}
+		err = ctx.BindJSON(event)
+		if err == nil {
+			message = event.ToString()
+			username = event.Sender.Login
+		} else {
+			Log(err.Error(), "error")
+		}
+	} else if event == "project_card" {
+		event := &webhookmodels.ProjectCardEventPayload{}
+		err = ctx.BindJSON(event)
+		if err == nil {
+			message = event.ToString()
+			username = event.Sender.Login
+		} else {
+			Log(err.Error(), "error")
+		}
+	} else if event == "project_column" {
+		event := &webhookmodels.ProjectColumnEventPayload{}
+		err = ctx.BindJSON(event)
+		if err == nil {
+			message = event.ToString()
+			username = event.Sender.Login
+		} else {
+			Log(err.Error(), "error")
+		}
+	} else if event == "pull_request" {
+		event := &webhookmodels.PullRequestEventPayload{}
+		err = ctx.BindJSON(event)
+		if err == nil {
+			message = event.ToString()
+			username = event.Sender.Login
+		} else {
+			Log(err.Error(), "error")
+		}
+	} else if event == "pull_request_review" {
+		event := &webhookmodels.PullRequestReviewEventPayload{}
+		err = ctx.BindJSON(event)
+		if err == nil {
+			message = event.ToString()
+			username = event.Sender.Login
+		} else {
+			Log(err.Error(), "error")
+		}
+	} else if event == "pull_request_review_comment" {
+		event := &webhookmodels.PullRequestReviewCommentEventPayload{}
+		err = ctx.BindJSON(event)
+		if err == nil {
+			message = event.ToString()
+			username = event.Sender.Login
+		} else {
+			Log(err.Error(), "error")
+		}
+	} else if event == "push" {
+		event := &webhookmodels.PushEventPayload{}
+		err = ctx.BindJSON(event)
+		if err == nil {
+			message = event.ToString()
+			username = event.Sender.Login
+		} else {
+			Log(fmt.Sprint("Bad Request: \n", ctx.Request.Form), "error")
+		}
+	} else {
+		Log(fmt.Sprint("Unsupported event: ", event), "error")
+	}
+
+	if len(username) > 0 && len(message) > 0 {
+		name, err := getNameFromUsername(username)
+		if err != nil {
+			return fmt.Sprint(name, " ", message), 0, nil
+		}
+		Log(fmt.Sprint("couldn't parse display name: ", username), "error")
+		return fmt.Sprint(username, " ", message), 0, nil
+	}
+
+	if err != nil {
+		Log(fmt.Sprint("error parsing body for event: ", event, "\n\tError:\t\t", err.Error()), "error")
+	}
+
+	return "", CodeInvalid, err
+}
+
+func getNameFromUsername(username string) (string, error) {
+	cfg := env.GetConfig()
+	userBody, err := MakeRequest(fmt.Sprint(cfg.BaseURL(), cfg.UserEndpoint), username, cfg.APIToken)
+	if err != nil {
+		return "", err
+	}
+	var payload map[string]interface{}
+	err = json.Unmarshal(*userBody, &payload)
+	if err != nil {
+		return "", err
+	}
+
+	name := strings.Split(payload["name"].(string), ", ")
+	if len(name) == 2 {
+		return fmt.Sprint(name[1], " ", name[0]), nil
+	}
+
+	Log(fmt.Sprint("issue finding name: ", username, " -- ", name), "error")
+
+	return username, nil
 }

--- a/server_test.go
+++ b/server_test.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/bmizerany/assert"
+	"github.com/mike-webster/repo-watcher/webhookmodels"
+)
+
+var server *Server
+
+func TestMain(t *testing.T) {
+	server = SetupServer("3199")
+
+	testHealthcheck(t)
+	testGithub(t)
+}
+
+func testHealthcheck(t *testing.T) {
+	resp := performRequest(server.Engine, "GET", "/", map[string]string{}, []byte{})
+	assert.Equal(t, CodeOK, resp.Code)
+}
+
+func testGithub(t *testing.T) {
+	cases := []struct {
+		Name            string
+		Path            string
+		Method          string
+		ExpectedCode    int
+		ExpectedMessage string
+		Headers         map[string]string
+		Body            interface{}
+	}{
+		{
+			Name:            "TestEmptyHeaders",
+			Path:            "/v1/github",
+			Method:          "POST",
+			ExpectedCode:    CodeInvalid,
+			Headers:         map[string]string{},
+			ExpectedMessage: `"{\"reason\":\"'ghRequestHeader.Event' Error:Field validation for 'Event' failed on the 'required' tag\",\"reason\":\"'ghRequestHeader.Secret' Error:Field validation for 'Secret' failed on the 'required' tag\"}"`,
+		},
+		{
+			Name:            "TestEmptyHeaderSecret",
+			Path:            "/v1/github",
+			Method:          "POST",
+			ExpectedCode:    CodeInvalid,
+			Headers:         map[string]string{"X-GitHub-Event": "test"},
+			ExpectedMessage: `"{\"reason\":\"'ghRequestHeader.Secret' Error:Field validation for 'Secret' failed on the 'required' tag\"}"`,
+		},
+		{
+			Name:            "TestEmptyHeaderEvent",
+			Path:            "/v1/github",
+			Method:          "POST",
+			ExpectedCode:    CodeInvalid,
+			ExpectedMessage: `"{\"reason\":\"'ghRequestHeader.Event' Error:Field validation for 'Event' failed on the 'required' tag\"}"`,
+			Headers:         map[string]string{"X-Hub-Signature": "test"},
+		},
+		{
+			Name:            "TestEmptyBody",
+			Path:            "/v1/github",
+			Method:          "POST",
+			ExpectedCode:    CodeInvalid,
+			ExpectedMessage: `"{\"reason\":\"'PushEventPayload.Ref' Error:Field validation for 'Ref' failed on the 'required' tag\"}"`,
+			Headers:         map[string]string{"X-GitHub-Event": "push", "X-Hub-Signature": "test"},
+			Body:            webhookmodels.PushEventPayload{},
+		},
+		{
+			Name:         "TestSuccess",
+			Path:         "/v1/github",
+			Method:       "POST",
+			ExpectedCode: CodeNoContent,
+			Headers:      map[string]string{"X-GitHub-Event": "push", "X-Hub-Signature": "push", "Content-Type": "application/json"},
+			Body: webhookmodels.PushEventPayload{
+				Ref: "test/ref",
+				URL: "www.testurl.com",
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.Name, func(t *testing.T) {
+			body, err := json.Marshal(c.Body)
+			if err != nil {
+				Log(fmt.Sprint("error parsing body: ", c.Body), "error")
+				assert.Equal(t, nil, err)
+			}
+			resp := performRequest(server.Engine, c.Method, c.Path, c.Headers, body)
+			assert.Equal(t, c.ExpectedCode, resp.Code, resp.Body.String())
+			if len(c.ExpectedMessage) > 0 {
+				assert.Equal(t, c.ExpectedMessage, resp.Body.String(), fmt.Sprintf("%v \n\t\t\t!=\n%v", c.ExpectedMessage, resp.Body.String()))
+			}
+		})
+	}
+}
+
+func performRequest(r http.Handler, method string, path string, headers map[string]string, body []byte) *httptest.ResponseRecorder {
+	var req *http.Request
+	if len(body) > 0 {
+		req, _ = http.NewRequest(method, path, bytes.NewBuffer(body))
+	} else {
+		req, _ = http.NewRequest(method, path, nil)
+	}
+
+	for k, v := range headers {
+		req.Header.Add(k, v)
+	}
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}

--- a/webhookmodels/card.go
+++ b/webhookmodels/card.go
@@ -1,0 +1,16 @@
+package webhookmodels
+
+import (
+	"time"
+)
+
+// Card represents a card on a project board
+type Card struct {
+	ID        int64     `json:"id"`
+	URL       string    `json:"html_url"`
+	ColumnID  int64     `json:"column_id"`
+	Note      string    `json:"note"`
+	Creator   User      `json:"creator"`
+	CreatedAt time.Time `json:"create_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}

--- a/webhookmodels/column.go
+++ b/webhookmodels/column.go
@@ -1,0 +1,10 @@
+package webhookmodels
+
+// Column represents a column from a project board
+type Column struct {
+	ID     int64      `json:"id"`
+	NodeID string     `json:"node_id"`
+	Name   string     `json:"name"`
+	Repo   Repository `json:"repository"`
+	Sender User       `json:"sender"`
+}

--- a/webhookmodels/comment.go
+++ b/webhookmodels/comment.go
@@ -1,0 +1,16 @@
+package webhookmodels
+
+import (
+	"time"
+)
+
+// Comment represets an issue comment
+type Comment struct {
+	ID        int64     `json:"id"`
+	URL       string    `json:"html_url"`
+	NodeID    string    `json:"node_id"`
+	Body      string    `json:"body"`
+	User      User      `json:"user"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}

--- a/webhookmodels/create_event.go
+++ b/webhookmodels/create_event.go
@@ -1,0 +1,22 @@
+package webhookmodels
+
+import (
+	"fmt"
+)
+
+// CreateEventPayload is the request received when a branch or tag is created
+// in a repository.
+//
+// https://developer.github.com/v3/activity/events/types/#createevent
+type CreateEventPayload struct {
+	Type        string     `json:"ref_type"`
+	Ref         string     `json:"ref"  binding:"required"`
+	Description string     `json:"description"`
+	Repo        Repository `json:"repository"`
+	Sender      User       `json:"sender"`
+}
+
+// ToString outputs a summary message of the event
+func (cep *CreateEventPayload) ToString() string {
+	return fmt.Sprintf("created a branch: %v", cep.Ref)
+}

--- a/webhookmodels/gollum_event.go
+++ b/webhookmodels/gollum_event.go
@@ -1,0 +1,30 @@
+package webhookmodels
+
+import (
+	"fmt"
+	"strings"
+)
+
+// GollumEventPayload is the request receiced when a wiki page is created
+// or updated.
+//
+// https://developer.github.com/v3/activity/events/types/#gollumevent
+type GollumEventPayload struct {
+	Pages  []Page     `json:"pages"  binding:"required"`
+	Repo   Repository `json:"repository"`
+	Sender User       `json:"sender"`
+}
+
+// Names will return the names of each page edited
+func (gep *GollumEventPayload) Names() string {
+	ret := []string{}
+	for _, p := range gep.Pages {
+		ret = append(ret, p.Name)
+	}
+	return strings.Join(ret, "\n")
+}
+
+// ToString outputs a summary message of the event
+func (gep *GollumEventPayload) ToString() string {
+	return fmt.Sprintf("updated some wiki content: \n%v", gep.Names())
+}

--- a/webhookmodels/issue.go
+++ b/webhookmodels/issue.go
@@ -1,0 +1,14 @@
+package webhookmodels
+
+// Issue represents a github issue
+type Issue struct {
+	ID       int64   `json:"id"`
+	URL      string  `json:"html_url"`
+	NodeID   string  `json:"node_id"`
+	Title    string  `json:"title"`
+	User     User    `json:"user"`
+	Labels   []Label `json:"labels"`
+	State    string  `json:"state"`
+	Assignee User    `json:"assignee"`
+	Body     string  `json:"body"`
+}

--- a/webhookmodels/issue_comment_event.go
+++ b/webhookmodels/issue_comment_event.go
@@ -1,0 +1,20 @@
+package webhookmodels
+
+import "fmt"
+
+// IssueCommentEventPayload is the request received when an issue comment is
+// created, edited, or deleted.
+//
+// https://developer.github.com/v3/activity/events/types/#issuecommentevent
+type IssueCommentEventPayload struct {
+	Action  string      `json:"action"  binding:"required"`
+	Issue   Issue       `json:"issue"`
+	Comment interface{} `json:"comment"`
+	Repo    Repository  `json:"repository"`
+	Sender  User        `json:"sender"`
+}
+
+// ToString outputs a summary message of the event
+func (icep *IssueCommentEventPayload) ToString() string {
+	return fmt.Sprintf("%v on an issue: \n----\n| Title: %v\n----\nComment: \n%v", icep.Action, icep.Issue.Title, icep.Comment)
+}

--- a/webhookmodels/issues_event.go
+++ b/webhookmodels/issues_event.go
@@ -1,0 +1,21 @@
+package webhookmodels
+
+import "fmt"
+
+// IssuesEventPayload is the request received when an issue is opened, edited,
+// deleted, pinned, unpinned, closed, reopened, assigned, unassigned, labeled,
+// unlabeled, locked, unlocked, transferred, milestoned, or demilestoned
+//
+// https://developer.github.com/v3/activity/events/types/#issuesevent
+type IssuesEventPayload struct {
+	Action  string      `json:"action"  binding:"required"`
+	Issue   Issue       `json:"issue"`
+	Changes interface{} `json:"changes"`
+	Repo    Repository  `json:"repository"`
+	Sender  User        `json:"sender"`
+}
+
+// ToString outputs a summary message of the event
+func (iep *IssuesEventPayload) ToString() string {
+	return fmt.Sprintf("%v an issue: \n----\n| Title: %v\n----\nBody: \n%v", iep.Action, iep.Issue.Title, iep.Issue.Body)
+}

--- a/webhookmodels/label.go
+++ b/webhookmodels/label.go
@@ -1,0 +1,9 @@
+package webhookmodels
+
+// Label represents a github label
+type Label struct {
+	ID     int64  `json:"id"`
+	NodeID string `json:"node_id"`
+	Name   string `json:"name"`
+	Color  string `json:"color"`
+}

--- a/webhookmodels/page.go
+++ b/webhookmodels/page.go
@@ -1,0 +1,11 @@
+package webhookmodels
+
+// Page represents a wiki page in a repo
+type Page struct {
+	Name    string `json:"page_name"`
+	Title   string `json:"title"`
+	Summary string `json:"summary"`
+	Action  string `json:"action"`
+	SHA     string `json:"sha"`
+	URL     string `json:"html_url"`
+}

--- a/webhookmodels/project_card_event.go
+++ b/webhookmodels/project_card_event.go
@@ -1,0 +1,19 @@
+package webhookmodels
+
+import "fmt"
+
+// ProjectCardEventPayload is the request received when a project card is created,
+// edited, moved, converted to an issue, or deleted.
+//
+// https://developer.github.com/v3/activity/events/types/#projectcardevent
+type ProjectCardEventPayload struct {
+	Action string     `json:"action"  binding:"required"`
+	Card   Card       `json:"project_card"`
+	Repo   Repository `json:"repository"`
+	Sender User       `json:"sender"`
+}
+
+// ToString outputs a summary message of the event
+func (pcep *ProjectCardEventPayload) ToString() string {
+	return fmt.Sprintf("%v a card: \n----\nNote: %v", pcep.Action, pcep.Card.Note)
+}

--- a/webhookmodels/project_column_event.go
+++ b/webhookmodels/project_column_event.go
@@ -1,0 +1,19 @@
+package webhookmodels
+
+import "fmt"
+
+// ProjectColumnEventPayload is the request received when a project column
+// is created, updated, moved, or deleted.
+//
+// https://developer.github.com/v3/activity/events/types/#projectcolumnevent
+type ProjectColumnEventPayload struct {
+	Action string     `json:"action"  binding:"required"`
+	Column Column     `json:"project_column"`
+	Repo   Repository `json:"repository"`
+	Sender User       `json:"sender"`
+}
+
+// ToString outputs a summary message of the event
+func (pcep *ProjectColumnEventPayload) ToString() string {
+	return fmt.Sprintf("%v a column: \n----\nName: %v", pcep.Action, pcep.Column.Name)
+}

--- a/webhookmodels/pull_request.go
+++ b/webhookmodels/pull_request.go
@@ -1,0 +1,21 @@
+package webhookmodels
+
+import "time"
+
+// PullRequest represents a github pull request
+type PullRequest struct {
+	ID        int64      `json:"id"`
+	NodeID    string     `json:"node_id"`
+	URL       string     `json:"html_url"`
+	Number    int        `json:"number"`
+	State     string     `json:"state"`
+	Title     string     `json:"title"`
+	User      User       `json:"user"`
+	Body      string     `json:"body"`
+	CreatedAt time.Time  `json:"created_at"`
+	UpdatedAt time.Time  `json:"updated_at"`
+	Assignee  User       `json:"assignee"`
+	Labels    []Label    `json:"labels"`
+	Repo      Repository `json:"repository"`
+	Sender    User       `json:"sender"`
+}

--- a/webhookmodels/pull_request_event.go
+++ b/webhookmodels/pull_request_event.go
@@ -1,0 +1,21 @@
+package webhookmodels
+
+import "fmt"
+
+// PullRequestEventPayload is the request received when a pull request is assigned,
+// unassigned, labeled, unlabeled, opened, edited, closed, reopened, synchronize,
+// ready_for_review, locked, unlocked or when a pull review is requested or removed.
+//
+// https://developer.github.com/v3/activity/events/types/#pullrequestevent
+type PullRequestEventPayload struct {
+	Action      string      `json:"action"  binding:"required"`
+	Number      int         `json:"number"`
+	PullRequest PullRequest `json:"pull_request"`
+	Repo        Repository  `json:"repository"`
+	Sender      User        `json:"sender"`
+}
+
+// ToString outputs a summary message of the event
+func (prep *PullRequestEventPayload) ToString() string {
+	return fmt.Sprintf("%v a pull request: \n----\n| Title: %v\n----\n| Body: \n%v", prep.Action, prep.PullRequest.Title, prep.PullRequest.Body)
+}

--- a/webhookmodels/pull_request_review_comment_event.go
+++ b/webhookmodels/pull_request_review_comment_event.go
@@ -1,0 +1,20 @@
+package webhookmodels
+
+import "fmt"
+
+// PullRequestReviewCommentEventPayload is the request received when a comment
+// on a pull request's unified dif is created, edited, or deleted.
+//
+// https://developer.github.com/v3/activity/events/types/#pullrequestreviewcommentevent
+type PullRequestReviewCommentEventPayload struct {
+	Action      string        `json:"action" binding:"required"`
+	PullRequest PullRequest   `json:"pull_request"`
+	Comment     ReviewComment `json:"comment"`
+	Repo        Repository    `json:"repository"`
+	Sender      User          `json:"sender"`
+}
+
+// ToString outputs a summary message of the event
+func (prrcep *PullRequestReviewCommentEventPayload) ToString() string {
+	return fmt.Sprintf("%v a comment on a pull request review for %v\n\t\tNew review state: %v\nComment: %v", prrcep.Action, prrcep.PullRequest.Title, prrcep.PullRequest.State, prrcep.Comment.Body)
+}

--- a/webhookmodels/pull_request_review_event.go
+++ b/webhookmodels/pull_request_review_event.go
@@ -1,0 +1,20 @@
+package webhookmodels
+
+import "fmt"
+
+// PullRequestReviewEventPayload is the request received when a pull request review
+// is submitted into a non-pending state, the body is edited, or the review is dismissed.
+//
+// https://developer.github.com/v3/activity/events/types/#pullrequestreviewevent
+type PullRequestReviewEventPayload struct {
+	Action      string      `json:"action" binding:"required"`
+	PullRequest PullRequest `json:"pull_request"`
+	Review      Review      `json:"review"`
+	Repo        Repository  `json:"repository"`
+	Sender      User        `json:"sender"`
+}
+
+// ToString outputs a summary message of the event
+func (prrep *PullRequestReviewEventPayload) ToString() string {
+	return fmt.Sprintf("%v a pull request review for %v\n\t\tNew review state: %v", prrep.Action, prrep.PullRequest.Title, prrep.PullRequest.State)
+}

--- a/webhookmodels/push_event.go
+++ b/webhookmodels/push_event.go
@@ -1,0 +1,34 @@
+package webhookmodels
+
+import (
+	"fmt"
+	"strings"
+)
+
+// PushEventPayload is the request received there is a push to a repository branch.
+//
+// https://developer.github.com/v3/activity/events/types/#pushevent
+type PushEventPayload struct {
+	Ref     string        `json:"ref" binding:"required"`
+	Commits []interface{} `json:"commits"`
+	Repo    Repository    `json:"repository"`
+	URL     string        `json:"html_url"`
+	Sender  User          `json:"sender"`
+}
+
+// CommitMessages returns a formatted list of strings from all commits
+// in the push
+func (pep *PushEventPayload) CommitMessages() string {
+	ret := []string{}
+	for _, c := range pep.Commits {
+		body := c.(map[string]interface{})
+		message := body["message"].(string)
+		ret = append(ret, message)
+	}
+	return strings.Join(ret, "\n")
+}
+
+// ToString outputs a summary message of the event
+func (pep *PushEventPayload) ToString() string {
+	return fmt.Sprintf("pushed some changes to %v\nCommits:\n> %v", pep.Ref, pep.CommitMessages())
+}

--- a/webhookmodels/repository.go
+++ b/webhookmodels/repository.go
@@ -1,0 +1,12 @@
+package webhookmodels
+
+// Repository represents a github repository
+type Repository struct {
+	ID          int64  `json:"id"`
+	NodeID      string `json:"node_id"`
+	Name        string `json:"name"`
+	Owner       User   `json:"owner"`
+	Sender      User   `json:"sender"`
+	URL         string `json:"html_url"`
+	Description string `json:"description"`
+}

--- a/webhookmodels/review.go
+++ b/webhookmodels/review.go
@@ -1,0 +1,14 @@
+package webhookmodels
+
+import "time"
+
+// Review repesents a github pull request review
+type Review struct {
+	ID          int64     `json:"id"`
+	NodeID      string    `json:"node_id"`
+	User        User      `json:"user"`
+	Body        string    `json:"body"`
+	SubmittedAt time.Time `json:"submitted_at"`
+	State       string    `json:"state"`
+	URL         string    `json:"html_url"`
+}

--- a/webhookmodels/review_comment.go
+++ b/webhookmodels/review_comment.go
@@ -1,0 +1,17 @@
+package webhookmodels
+
+import "time"
+
+// ReviewComment represents a user's comment on a pull request
+type ReviewComment struct {
+	ID             int64     `json:"id"`
+	ReviewID       int64     `json:"pull_request_review_id"`
+	NodeID         string    `json:"node_id"`
+	Path           string    `json:"path"`
+	URL            string    `json:"html_url"`
+	User           User      `json:"user"`
+	Body           string    `json:"body"`
+	CreatedAt      time.Time `json:"created_at"`
+	UpdatedAt      time.Time `json:"updated_at"`
+	PullRequestURL string    `json:"pull_request_url"`
+}

--- a/webhookmodels/user.go
+++ b/webhookmodels/user.go
@@ -1,0 +1,10 @@
+package webhookmodels
+
+// User represents a github user
+type User struct {
+	ID        int64  `json:"id"`
+	Login     string `json:"login"`
+	NodeID    string `json:"node_id"`
+	AvatarURL string `json:"avatar_url"`
+	URL       string `json:"html_url"`
+}


### PR DESCRIPTION
## What is this?
I had initially built this app as a way to get desktop notifications for repository events.  That quickly evolved into sending slack messages. Which led me to getting webhook access.

## What are these changes?
This is implementing the webhook side of things.  Instead of pulling for events, we'll have them sent to us.

## Assumptions
- This is something that's a little hard to test until it hits production, so there might be a few followup hotfixes.
    - If anything _is_ broken, I should be able to revert back to the `v1.0` tag
        - I might just be able to switch back to the "solo" mode